### PR TITLE
Add markdown support for task description

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
+gem "redcarpet"
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    redcarpet (3.5.1)
     regexp_parser (2.5.0)
     reline (0.3.1)
       io-console (~> 0.5)
@@ -347,6 +348,7 @@ DEPENDENCIES
   jsbundling-rails
   puma (~> 5.0)
   rails (~> 7.0.3, >= 7.0.3.1)
+  redcarpet
   rspec-rails
   rubocop-rails
   rubocop-rspec

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  def markdown
+    @markdown ||= begin
+                    renderer = Redcarpet::Render::HTML.new(link_attributes: { target: "_blank" })
+                    Redcarpet::Markdown.new(renderer, no_intra_emphasis: true, autolink: true, underline: true)
+                  end
+  end
 end

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -4,5 +4,5 @@ h3
   ' Owner:
   = @task.owner&.name
 p
-  = @task.description
+  == markdown.render(@task.description)
 = button_to "Edit Task", edit_task_path(@task), method: :get


### PR DESCRIPTION
Renders the `description` field on the show page using the RedCarpet markdown processor.