### PR TITLE
Change markdown options to match EasyMDE

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,8 +3,14 @@
 module ApplicationHelper
   def markdown
     @markdown ||= begin
-                    renderer = Redcarpet::Render::HTML.new(link_attributes: { target: "_blank" })
-                    Redcarpet::Markdown.new(renderer, no_intra_emphasis: true, autolink: true, underline: true)
+                    opts = optionize(%i[with_toc_data hard_wrap gh_blockcode])
+                    opts[:link_attributes] = { target: "_blank" }
+                    renderer = Redcarpet::Render::HTML.new(opts)
+                    Redcarpet::Markdown.new(renderer, optionize(%i[no_intra_emphasis autolink underline fenced_code_blocks tables strikethrough space_after_headers]))
                   end
+  end
+
+  def optionize(options)
+    options.each_with_object({}) { |option, memo| memo[option] = true }
   end
 end


### PR DESCRIPTION
Change the markdown options for Redcarpet to match the Markdown produced by EasyMDE.