### PR TITLE
Allow blank owner

### DIFF
--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -5,6 +5,7 @@
 
 = form.label :owner_id, "owner:"
 = form.select :owner_id, authorized_users, { :include_blank => true }, disabled: cannot?(@current_action, @task, :owner_id)
+= form.select :owner_id, authorized_users, { :include_blank => true }, disabled: cannot?(@current_action, @task, :owner_id)
 
 div
   = form.label :description, "description:"

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -5,7 +5,6 @@
 
 = form.label :owner_id, "owner:"
 = form.select :owner_id, authorized_users, { :include_blank => true }, disabled: cannot?(@current_action, @task, :owner_id)
-= form.select :owner_id, authorized_users, { :include_blank => true }, disabled: cannot?(@current_action, @task, :owner_id)
 
 div
   = form.label :description, "description:"

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -4,7 +4,7 @@
 = form.text_field :title, size: "80", disabled: cannot?(@current_action, @task, :title)
 
 = form.label :owner_id, "owner:"
-= form.select :owner_id, authorized_users, { include_blank: true }, disabled: cannot?(@current_action, @task, :owner_id)
+= form.select :owner_id, authorized_users, include_blank: true, disabled: cannot?(@current_action, @task, :owner_id)
 
 div
   = form.label :description, "description:"

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -4,7 +4,7 @@
 = form.text_field :title, size: "80", disabled: cannot?(@current_action, @task, :title)
 
 = form.label :owner_id, "owner:"
-= form.select :owner_id, authorized_users, {}, disabled: cannot?(@current_action, @task, :owner_id)
+= form.select :owner_id, authorized_users, { :include_blank => true }, disabled: cannot?(@current_action, @task, :owner_id)
 
 div
   = form.label :description, "description:"

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -4,7 +4,7 @@
 = form.text_field :title, size: "80", disabled: cannot?(@current_action, @task, :title)
 
 = form.label :owner_id, "owner:"
-= form.select :owner_id, authorized_users, { :include_blank => true }, disabled: cannot?(@current_action, @task, :owner_id)
+= form.select :owner_id, authorized_users, { include_blank: true }, disabled: cannot?(@current_action, @task, :owner_id)
 
 div
   = form.label :description, "description:"


### PR DESCRIPTION
One component of [quicksilver task 69](https://quicksilver.engineering.mercuryanalytics.com/tasks/69) to allow "blank" owner

- Adds form field option to include blank