### PR TITLE
feat: add MCP engineer workflow tools with identity gating

### DIFF
--- a/app/controllers/mcp_controller.rb
+++ b/app/controllers/mcp_controller.rb
@@ -14,7 +14,7 @@ class McpController < ApplicationController
     payload = parse_payload
     validate_protocol_version!(payload)
     server = Mcp::Server.new
-    response = server.handle(payload)
+    response = server.handle(payload, current_user:)
     return head :accepted if response.nil?
 
     render json: response, status: response_status(response)
@@ -31,6 +31,10 @@ class McpController < ApplicationController
   end
 
   private
+
+  def current_user
+    Mcp::CurrentUser.new(email: request.headers["X-Quicksilver-User-Email"])
+  end
 
   def parse_payload
     raw_body = request.body.read
@@ -64,6 +68,7 @@ class McpController < ApplicationController
     error_code = response.dig("error", "code")
     return :bad_request if [-32_700, -32_600, -32_602].include?(error_code)
     return :not_found if error_code == -32_002
+    return :forbidden if error_code == -32_003
 
     :ok
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -18,6 +18,7 @@ class Task < ApplicationRecord
   scope :active, -> { where.not(started_at: nil).where(completed_at: nil) }
   scope :recently_completed, -> { where("completed_at > ?", 1.month.ago) }
   scope :approved, -> { where(approved: true) }
+  scope :backlog, -> { where(board_id: nil) }
   scope :wishlist, -> { where(board: Board.wishlist) }
   scope :suggestions, -> { where(board: Board.suggestions) }
   scope :highest_priority, -> { order(priority: :desc).limit(15) }

--- a/app/services/mcp/current_user.rb
+++ b/app/services/mcp/current_user.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Mcp
+  # Resolves the per-connection identity supplied via the
+  # X-Quicksilver-User-Email header into a User. Isolating all identity logic
+  # here means a future migration to per-engineer tokens only has to change how
+  # the user is derived (e.g. from the bearer token) without touching handlers.
+  class CurrentUser
+    attr_reader :email, :user
+
+    def initialize(email:)
+      @email = email.presence
+      @user = User.find_by(email: @email) if @email
+    end
+
+    def resolved?
+      user.present?
+    end
+
+    def engineer_or_admin?
+      resolved? && (user.engineer? || user.admin?)
+    end
+  end
+end

--- a/app/services/mcp/errors.rb
+++ b/app/services/mcp/errors.rb
@@ -41,5 +41,11 @@ module Mcp
         super(message, code: -32_002, data:)
       end
     end
+
+    class Forbidden < Base
+      def initialize(message = "Forbidden", data: nil)
+        super(message, code: -32_003, data:)
+      end
+    end
   end
 end

--- a/app/services/mcp/handlers/initialize_handler.rb
+++ b/app/services/mcp/handlers/initialize_handler.rb
@@ -3,7 +3,7 @@
 module Mcp
   module Handlers
     class InitializeHandler
-      def call(params:, current_user: nil) # rubocop:disable Lint/UnusedMethodArgument
+      def call(params:, **)
         client_info = params.fetch("clientInfo", {})
         protocol_version = params["protocolVersion"]
         raise Errors::InvalidParams, "protocolVersion is required" if protocol_version.blank?

--- a/app/services/mcp/handlers/initialize_handler.rb
+++ b/app/services/mcp/handlers/initialize_handler.rb
@@ -3,7 +3,7 @@
 module Mcp
   module Handlers
     class InitializeHandler
-      def call(params:)
+      def call(params:, current_user: nil) # rubocop:disable Lint/UnusedMethodArgument
         client_info = params.fetch("clientInfo", {})
         protocol_version = params["protocolVersion"]
         raise Errors::InvalidParams, "protocolVersion is required" if protocol_version.blank?

--- a/app/services/mcp/handlers/initialized_handler.rb
+++ b/app/services/mcp/handlers/initialized_handler.rb
@@ -3,7 +3,7 @@
 module Mcp
   module Handlers
     class InitializedHandler
-      def call(params:) # rubocop:disable Lint/UnusedMethodArgument
+      def call(params:, current_user: nil) # rubocop:disable Lint/UnusedMethodArgument
         {}
       end
     end

--- a/app/services/mcp/handlers/initialized_handler.rb
+++ b/app/services/mcp/handlers/initialized_handler.rb
@@ -3,7 +3,7 @@
 module Mcp
   module Handlers
     class InitializedHandler
-      def call(params:, current_user: nil) # rubocop:disable Lint/UnusedMethodArgument
+      def call(**)
         {}
       end
     end

--- a/app/services/mcp/handlers/resources_list_handler.rb
+++ b/app/services/mcp/handlers/resources_list_handler.rb
@@ -3,7 +3,7 @@
 module Mcp
   module Handlers
     class ResourcesListHandler
-      def call(params:, current_user: nil) # rubocop:disable Lint/UnusedMethodArgument
+      def call(**)
         resources = task_resources + board_resources
         {
           "resources" => resources,

--- a/app/services/mcp/handlers/resources_list_handler.rb
+++ b/app/services/mcp/handlers/resources_list_handler.rb
@@ -3,7 +3,7 @@
 module Mcp
   module Handlers
     class ResourcesListHandler
-      def call(params:) # rubocop:disable Lint/UnusedMethodArgument
+      def call(params:, current_user: nil) # rubocop:disable Lint/UnusedMethodArgument
         resources = task_resources + board_resources
         {
           "resources" => resources,

--- a/app/services/mcp/handlers/resources_read_handler.rb
+++ b/app/services/mcp/handlers/resources_read_handler.rb
@@ -3,7 +3,7 @@
 module Mcp
   module Handlers
     class ResourcesReadHandler
-      def call(params:)
+      def call(params:, current_user: nil) # rubocop:disable Lint/UnusedMethodArgument
         uri = params["uri"]
         raise Errors::InvalidParams, "uri is required" if uri.blank?
 

--- a/app/services/mcp/handlers/resources_read_handler.rb
+++ b/app/services/mcp/handlers/resources_read_handler.rb
@@ -3,7 +3,7 @@
 module Mcp
   module Handlers
     class ResourcesReadHandler
-      def call(params:, current_user: nil) # rubocop:disable Lint/UnusedMethodArgument
+      def call(params:, **)
         uri = params["uri"]
         raise Errors::InvalidParams, "uri is required" if uri.blank?
 

--- a/app/services/mcp/handlers/tools_call_handler.rb
+++ b/app/services/mcp/handlers/tools_call_handler.rb
@@ -3,29 +3,133 @@
 module Mcp
   module Handlers
     class ToolsCallHandler
-      def call(params:)
+      MUTATING_TOOLS = %w[create_task update_task complete_task claim_task accept_task].freeze
+      DEFAULT_LIST_LIMIT = 50
+
+      def call(params:, current_user: nil)
         name = params["name"]
         arguments = params.fetch("arguments", {})
         raise Errors::InvalidParams, "name is required" if name.blank?
         raise Errors::InvalidParams, "arguments must be an object" unless arguments.is_a?(Hash)
 
-        result = execute_tool(name, arguments)
+        authorize_mutation!(name, current_user)
+        result = execute_tool(name, arguments, current_user)
         build_response(result)
       end
 
       private
 
-      def execute_tool(name, arguments)
+      def authorize_mutation!(name, current_user)
+        return unless MUTATING_TOOLS.include?(name)
+        raise Errors::Forbidden.new(data: "identity required") unless current_user&.resolved?
+        raise Errors::Forbidden.new(data: "not authorized") unless current_user.engineer_or_admin?
+      end
+
+      def execute_tool(name, arguments, current_user)
         case name
-        when "create_task"
-          create_task(arguments)
-        when "update_task"
-          update_task(arguments)
-        when "complete_task"
-          complete_task(arguments)
-        else
-          raise Errors::InvalidParams, "Unknown tool #{name}"
+        when "create_task" then create_task(arguments)
+        when "update_task" then update_task(arguments)
+        when "complete_task" then complete_task(arguments)
+        when "claim_task" then claim_task(arguments, current_user)
+        when "accept_task" then accept_task(arguments)
+        else read_only_tool(name, arguments, current_user)
         end
+      end
+
+      def read_only_tool(name, arguments, current_user)
+        case name
+        when "available_work" then available_work
+        when "proposed_work" then proposed_work
+        when "list_tasks" then list_tasks(arguments, current_user)
+        else raise Errors::InvalidParams, "Unknown tool #{name}"
+        end
+      end
+
+      def list_tasks(arguments, current_user)
+        scope = Task.all
+        scope = filter_by_board(scope, arguments)
+        scope = filter_by_status(scope, arguments["status"])
+        scope = filter_by_owner(scope, arguments["owner"], current_user)
+        tasks_response(scope.limit(list_limit(arguments["limit"])))
+      end
+
+      def filter_by_board(scope, arguments)
+        return scope unless arguments.key?("board")
+
+        name = arguments["board"]
+        return scope.backlog if name.blank?
+
+        board = Board.find_by(name:)
+        raise Errors::InvalidParams, "Unknown board: #{name}" if board.nil?
+
+        scope.where(board:)
+      end
+
+      def filter_by_status(scope, status)
+        return scope if status.blank?
+
+        case status
+        when "available" then scope.available
+        when "active" then scope.active
+        when "recently_completed" then scope.recently_completed
+        else raise Errors::InvalidParams, "Unknown status: #{status}"
+        end
+      end
+
+      def filter_by_owner(scope, owner, current_user)
+        return scope if owner.blank?
+
+        if owner == "me"
+          raise Errors::InvalidParams, "owner: me requires an identified user" unless current_user&.resolved?
+
+          return scope.where(owner: current_user.user)
+        end
+
+        user = User.find_by(email: owner)
+        user ? scope.where(owner: user) : scope.none
+      end
+
+      def list_limit(value)
+        limit = value.to_i
+        limit.positive? ? limit : DEFAULT_LIST_LIMIT
+      end
+
+      def accept_task(arguments)
+        task = find_task(arguments)
+        task.board_id = nil
+        task.approved = false
+        persist_task(task)
+      end
+
+      def claim_task(arguments, current_user)
+        task = find_task(arguments)
+        raise Errors::InvalidParams, "Task is already started" if task.started_at.present?
+        raise Errors::InvalidParams, "Task is owned by another user" if task.owner_id.present? && task.owner_id != current_user.user.id
+
+        task.owner = current_user.user
+        task.started_at = Date.current
+        persist_task(task)
+      end
+
+      def find_task(arguments)
+        id = arguments["id"]
+        raise Errors::InvalidParams, "id is required" if id.blank?
+
+        Task.find(id)
+      rescue ActiveRecord::RecordNotFound
+        raise Errors::ResourceNotFound, "Task not found: #{id}"
+      end
+
+      def available_work
+        tasks_response(Task.backlog.available.sort)
+      end
+
+      def proposed_work
+        tasks_response(Task.wishlist.approved.highest_priority)
+      end
+
+      def tasks_response(tasks)
+        { "tasks" => tasks.map { |task| task_payload(task) } }
       end
 
       def build_response(result)
@@ -51,25 +155,15 @@ module Mcp
       end
 
       def update_task(arguments)
-        id = arguments["id"]
-        raise Errors::InvalidParams, "id is required" if id.blank?
-
-        task = Task.find(id)
+        task = find_task(arguments)
         task.assign_attributes(permitted_task_attributes(arguments))
         persist_task(task)
-      rescue ActiveRecord::RecordNotFound
-        raise Errors::ResourceNotFound, "Task not found: #{id}"
       end
 
       def complete_task(arguments)
-        id = arguments["id"]
-        raise Errors::InvalidParams, "id is required" if id.blank?
-
-        task = Task.find(id)
+        task = find_task(arguments)
         task.completed_at = parse_completed_at(arguments["completed_at"])
         persist_task(task)
-      rescue ActiveRecord::RecordNotFound
-        raise Errors::ResourceNotFound, "Task not found: #{id}"
       end
 
       def permitted_task_attributes(arguments)

--- a/app/services/mcp/handlers/tools_list_handler.rb
+++ b/app/services/mcp/handlers/tools_list_handler.rb
@@ -3,17 +3,82 @@
 module Mcp
   module Handlers
     class ToolsListHandler
-      def call(params:) # rubocop:disable Lint/UnusedMethodArgument
+      def call(params:, current_user: nil) # rubocop:disable Lint/UnusedMethodArgument
         {
           "tools" => [
             create_task_tool,
             update_task_tool,
-            complete_task_tool
+            complete_task_tool,
+            available_work_tool,
+            proposed_work_tool,
+            claim_task_tool,
+            accept_task_tool,
+            list_tasks_tool
           ]
         }
       end
 
       private
+
+      def available_work_tool
+        {
+          "name" => "available_work",
+          "description" => "List available work on the engineering backlog (unstarted, unassigned), in size order.",
+          "inputSchema" => { "type" => "object", "properties" => {} }
+        }
+      end
+
+      def proposed_work_tool
+        {
+          "name" => "proposed_work",
+          "description" => "List approved tasks proposed for the backlog (the wishlist inbound queue), highest priority first.",
+          "inputSchema" => { "type" => "object", "properties" => {} }
+        }
+      end
+
+      def claim_task_tool
+        {
+          "name" => "claim_task",
+          "description" => "Claim a backlog task for yourself: assigns it to you and starts it (sets owner and started_at). Requires an engineer identity.",
+          "inputSchema" => {
+            "type" => "object",
+            "properties" => {
+              "id" => { "type" => "integer" }
+            },
+            "required" => ["id"]
+          }
+        }
+      end
+
+      def accept_task_tool
+        {
+          "name" => "accept_task",
+          "description" => "Accept a proposed task onto the backlog: removes its board and clears approved. Requires an engineer identity.",
+          "inputSchema" => {
+            "type" => "object",
+            "properties" => {
+              "id" => { "type" => "integer" }
+            },
+            "required" => ["id"]
+          }
+        }
+      end
+
+      def list_tasks_tool
+        {
+          "name" => "list_tasks",
+          "description" => "Query tasks by board, status, and owner.",
+          "inputSchema" => {
+            "type" => "object",
+            "properties" => {
+              "board" => { "type" => "string", "description" => "Board name (wishlist/suggestions/bizdev); null or empty for the backlog. Omit to span all boards." },
+              "status" => { "type" => "string", "description" => "One of available, active, recently_completed." },
+              "owner" => { "type" => "string", "description" => "Owner email, or 'me' for the identified user." },
+              "limit" => { "type" => "integer", "description" => "Maximum number of tasks (default 50)." }
+            }
+          }
+        }
+      end
 
       def create_task_tool
         {

--- a/app/services/mcp/handlers/tools_list_handler.rb
+++ b/app/services/mcp/handlers/tools_list_handler.rb
@@ -3,7 +3,7 @@
 module Mcp
   module Handlers
     class ToolsListHandler
-      def call(params:, current_user: nil) # rubocop:disable Lint/UnusedMethodArgument
+      def call(**)
         {
           "tools" => [
             create_task_tool,

--- a/app/services/mcp/server.rb
+++ b/app/services/mcp/server.rb
@@ -15,10 +15,10 @@ module Mcp
       }
     end
 
-    def handle(payload)
+    def handle(payload, current_user: nil)
       validate_payload!(payload)
       handler = @handlers.fetch(payload["method"]) { raise Errors::MethodNotFound }
-      result = handler.call(params: payload.fetch("params", {}))
+      result = handler.call(params: payload.fetch("params", {}), current_user:)
       return nil if payload["id"].nil?
 
       build_result(payload["id"], result)

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -6,6 +6,7 @@ Quicksilver provides an MCP server interface for programmatic access to tasks an
 
 - [Authentication](#authentication)
 - [Required Headers](#required-headers)
+  - [Identity Header (`X-Quicksilver-User-Email`)](#identity-header-x-quicksilver-user-email)
 - [Protocol Version](#protocol-version)
 - [Endpoints](#endpoints)
 - [Methods](#methods)
@@ -53,6 +54,20 @@ For all methods except `initialize`, you must also include:
 ```
 MCP-Protocol-Version: 2025-06-18
 ```
+
+### Identity Header (`X-Quicksilver-User-Email`)
+
+Mutating tools are gated on the caller's identity. Supply your email once in your MCP client configuration:
+
+```
+X-Quicksilver-User-Email: you@mercuryanalytics.com
+```
+
+- **Optional** for read-only tools (`available_work`, `proposed_work`, `list_tasks`) and all `resources/*` reads.
+- **Required** for every mutating tool (`create_task`, `update_task`, `complete_task`, `claim_task`, `accept_task`). The resolved user must be an engineer or admin; otherwise the call returns [`-32003 Forbidden`](#error-codes).
+- `list_tasks` uses the header only to resolve `owner: me`.
+
+The connection-level bearer token is still required and is checked before any tool runs. Identity is resolved independently of the token (see `Mcp::CurrentUser`), so a future move to per-engineer tokens will not change this tool contract.
 
 ## Protocol Version
 
@@ -318,6 +333,47 @@ curl -X POST http://localhost:3000/mcp \
           },
           "required": ["id"]
         }
+      },
+      {
+        "name": "available_work",
+        "description": "List available work on the engineering backlog (unstarted, unassigned), in size order.",
+        "inputSchema": { "type": "object", "properties": {} }
+      },
+      {
+        "name": "proposed_work",
+        "description": "List approved tasks proposed for the backlog (the wishlist inbound queue), highest priority first.",
+        "inputSchema": { "type": "object", "properties": {} }
+      },
+      {
+        "name": "claim_task",
+        "description": "Claim a backlog task for yourself: assigns it to you and starts it (sets owner and started_at). Requires an engineer identity.",
+        "inputSchema": {
+          "type": "object",
+          "properties": { "id": { "type": "integer" } },
+          "required": ["id"]
+        }
+      },
+      {
+        "name": "accept_task",
+        "description": "Accept a proposed task onto the backlog: removes its board and clears approved. Requires an engineer identity.",
+        "inputSchema": {
+          "type": "object",
+          "properties": { "id": { "type": "integer" } },
+          "required": ["id"]
+        }
+      },
+      {
+        "name": "list_tasks",
+        "description": "Query tasks by board, status, and owner.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "board": { "type": "string", "description": "Board name (wishlist/suggestions/bizdev); null or empty for the backlog. Omit to span all boards." },
+            "status": { "type": "string", "description": "One of available, active, recently_completed." },
+            "owner": { "type": "string", "description": "Owner email, or 'me' for the identified user." },
+            "limit": { "type": "integer", "description": "Maximum number of tasks (default 50)." }
+          }
+        }
       }
     ]
   }
@@ -327,6 +383,8 @@ curl -X POST http://localhost:3000/mcp \
 ### Call Tool
 
 Executes a tool with the specified arguments.
+
+> **Identity:** the mutating tools below (`create_task`, `update_task`, `complete_task`, `claim_task`, `accept_task`) require an engineer/admin identity supplied via the [`X-Quicksilver-User-Email`](#identity-header-x-quicksilver-user-email) header. The read-only tools (`available_work`, `proposed_work`, `list_tasks`) do not.
 
 #### Create Task
 
@@ -338,6 +396,7 @@ curl -X POST http://localhost:3000/mcp \
   -H "Accept: application/json, text/event-stream" \
   -H "Content-Type: application/json" \
   -H "MCP-Protocol-Version: 2025-06-18" \
+  -H "X-Quicksilver-User-Email: you@mercuryanalytics.com" \
   -d '{
     "jsonrpc": "2.0",
     "method": "tools/call",
@@ -381,6 +440,7 @@ curl -X POST http://localhost:3000/mcp \
   -H "Accept: application/json, text/event-stream" \
   -H "Content-Type: application/json" \
   -H "MCP-Protocol-Version: 2025-06-18" \
+  -H "X-Quicksilver-User-Email: you@mercuryanalytics.com" \
   -d '{
     "jsonrpc": "2.0",
     "method": "tools/call",
@@ -423,6 +483,7 @@ curl -X POST http://localhost:3000/mcp \
   -H "Accept: application/json, text/event-stream" \
   -H "Content-Type: application/json" \
   -H "MCP-Protocol-Version: 2025-06-18" \
+  -H "X-Quicksilver-User-Email: you@mercuryanalytics.com" \
   -d '{
     "jsonrpc": "2.0",
     "method": "tools/call",
@@ -454,6 +515,169 @@ curl -X POST http://localhost:3000/mcp \
 }
 ```
 
+#### Available Work
+
+Lists unstarted, unassigned tasks on the engineering backlog (`board_id = null`), in size order. Read-only — no identity header required.
+
+**Request:**
+
+```bash
+curl -X POST http://localhost:3000/mcp \
+  -H "Authorization: Bearer your-secret-token" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Content-Type: application/json" \
+  -H "MCP-Protocol-Version: 2025-06-18" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "tools/call",
+    "id": 9,
+    "params": { "name": "available_work", "arguments": {} }
+  }'
+```
+
+**Response:** the inner `text` is `{"tasks":[ ... ]}`, where each entry is a full task payload.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 9,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"tasks\":[{\"id\":12,\"title\":\"Fix flaky spec\",\"description\":\"...\",\"status\":null,\"size\":\"small\",\"priority\":3,\"board_id\":null,\"owner_id\":null,\"approved\":false,\"started_at\":null,\"expected_at\":null,\"completed_at\":null,\"created_at\":\"2026-06-01T10:00:00Z\",\"updated_at\":\"2026-06-01T10:00:00Z\"}]}"
+      }
+    ]
+  }
+}
+```
+
+#### Proposed Work
+
+Lists approved tasks on the wishlist (the backlog's inbound queue), highest priority first. Read-only.
+
+**Request:**
+
+```bash
+curl -X POST http://localhost:3000/mcp \
+  -H "Authorization: Bearer your-secret-token" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Content-Type: application/json" \
+  -H "MCP-Protocol-Version: 2025-06-18" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "tools/call",
+    "id": 10,
+    "params": { "name": "proposed_work", "arguments": {} }
+  }'
+```
+
+**Response:** `{"tasks":[ ... ]}`, same entry shape as `available_work`.
+
+#### Claim Task
+
+Claims a backlog task for the calling engineer: sets `owner_id` to the resolved user **and** `started_at` to today in a single save. Returns the full task. Errors with `-32602` if the task is already started or owned by another user. **Requires an engineer identity.**
+
+**Request:**
+
+```bash
+curl -X POST http://localhost:3000/mcp \
+  -H "Authorization: Bearer your-secret-token" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Content-Type: application/json" \
+  -H "MCP-Protocol-Version: 2025-06-18" \
+  -H "X-Quicksilver-User-Email: you@mercuryanalytics.com" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "tools/call",
+    "id": 11,
+    "params": { "name": "claim_task", "arguments": { "id": 12 } }
+  }'
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 11,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"uri\":\"quicksilver://tasks/12\",\"task\":{...\"owner_id\":7,\"started_at\":\"2026-06-08\"}}"
+      }
+    ]
+  }
+}
+```
+
+#### Accept Task
+
+Pulls a proposed task onto the backlog: sets `board_id = null` **and** `approved = false` (mirroring the board-move rule in `TasksController#update`). Returns the full task. **Requires an engineer identity.**
+
+**Request:**
+
+```bash
+curl -X POST http://localhost:3000/mcp \
+  -H "Authorization: Bearer your-secret-token" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Content-Type: application/json" \
+  -H "MCP-Protocol-Version: 2025-06-18" \
+  -H "X-Quicksilver-User-Email: you@mercuryanalytics.com" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "tools/call",
+    "id": 12,
+    "params": { "name": "accept_task", "arguments": { "id": 30 } }
+  }'
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 12,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"uri\":\"quicksilver://tasks/30\",\"task\":{...\"board_id\":null,\"approved\":false}}"
+      }
+    ]
+  }
+}
+```
+
+#### List Tasks
+
+Flexible query across boards, status, and owner. All arguments are optional. Read-only; the identity header is used only to resolve `owner: "me"`.
+
+- `board`: board name (`wishlist`/`suggestions`/`bizdev`); `null` or empty for the backlog; omit to span all boards. An unknown name returns `-32602`.
+- `status`: one of `available`, `active`, `recently_completed`. An unknown value returns `-32602`.
+- `owner`: an owner email, or the literal `me` for the identified user (`-32602` if no identity is supplied).
+- `limit`: maximum number of tasks (default 50).
+
+**Request — "what am I working on":**
+
+```bash
+curl -X POST http://localhost:3000/mcp \
+  -H "Authorization: Bearer your-secret-token" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Content-Type: application/json" \
+  -H "MCP-Protocol-Version: 2025-06-18" \
+  -H "X-Quicksilver-User-Email: you@mercuryanalytics.com" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "tools/call",
+    "id": 13,
+    "params": { "name": "list_tasks", "arguments": { "owner": "me", "status": "active" } }
+  }'
+```
+
+**Response:** `{"tasks":[ ... ]}`, same entry shape as `available_work`.
+
 ## Error Codes
 
 The MCP interface uses standard JSON-RPC 2.0 error codes:
@@ -465,8 +689,30 @@ The MCP interface uses standard JSON-RPC 2.0 error codes:
 | -32601  | Method Not Found    | The requested method does not exist                   | 200*        |
 | -32602  | Invalid Params      | Invalid method parameters                             | 400         |
 | -32002  | Resource Not Found  | The requested resource does not exist (MCP-specific)  | 404         |
+| -32003  | Forbidden           | Mutating tool called without a resolved engineer/admin identity (MCP-specific) | 403 |
 
 *Note: Method Not Found returns HTTP 200 with an error in the JSON-RPC response body per the JSON-RPC 2.0 specification.
+
+**Forbidden (`-32003`):**
+
+Returned by a mutating tool when the caller lacks an authorized identity. The `data` field distinguishes the cause:
+
+- `"identity required"` — the `X-Quicksilver-User-Email` header is missing or resolves to no user.
+- `"not authorized"` — the resolved user is not an engineer or admin.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 11,
+  "error": {
+    "code": -32003,
+    "message": "Forbidden",
+    "data": "identity required"
+  }
+}
+```
+
+HTTP Status: 403
 
 **Error Response Format:**
 

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe Task, type: :model do
     expect(described_class.recently_completed.count).to eq(1)
   end
 
+  it "has a backlog scope for tasks without a board" do
+    create(:task, board: nil)
+    create(:task, board: create(:board))
+    expect(described_class.backlog.count).to eq(1)
+  end
+
   it "allows valid sizes" do
     expect(build(:task, size: "small")).to be_valid
   end

--- a/spec/requests/mcp_spec.rb
+++ b/spec/requests/mcp_spec.rb
@@ -13,9 +13,24 @@ RSpec.describe "MCP", type: :request do
   end
 
   let(:valid_token) { "test-token" }
+  let(:engineer) { create(:engineer_user) }
 
   before do
     allow(Rails.application.credentials).to receive(:mcp_auth_token).and_return(valid_token)
+  end
+
+  def engineer_headers
+    valid_headers.merge("X-Quicksilver-User-Email" => engineer.email)
+  end
+
+  def post_tool_call(name, arguments: {}, headers: valid_headers, id: 1)
+    post "/mcp",
+         params: { jsonrpc: "2.0", method: "tools/call", id:, params: { name:, arguments: } }.to_json,
+         headers:
+  end
+
+  def tool_result
+    JSON.parse(JSON.parse(response.body).dig("result", "content", 0, "text"))
   end
 
   describe "GET /mcp" do
@@ -365,6 +380,17 @@ RSpec.describe "MCP", type: :request do
         expect(body["result"]).to be_a(Hash)
         expect(body["result"]["tools"]).to be_an(Array)
       end
+
+      it "lists the workflow tools" do
+        post "/mcp",
+             params: { jsonrpc: "2.0", method: "tools/list", id: 4 }.to_json,
+             headers: valid_headers
+
+        names = JSON.parse(response.body).dig("result", "tools").map { |t| t["name"] }
+        expect(names).to include(
+          "available_work", "proposed_work", "claim_task", "accept_task", "list_tasks"
+        )
+      end
     end
 
     context "with tools/call" do
@@ -381,7 +407,7 @@ RSpec.describe "MCP", type: :request do
                  }
                }
              }.to_json,
-             headers: valid_headers
+             headers: engineer_headers
 
         expect(response).to have_http_status(:ok)
         body = JSON.parse(response.body)
@@ -408,7 +434,7 @@ RSpec.describe "MCP", type: :request do
                  }
                }
              }.to_json,
-             headers: valid_headers
+             headers: engineer_headers
 
         expect(response).to have_http_status(:ok)
         body = JSON.parse(response.body)
@@ -430,7 +456,7 @@ RSpec.describe "MCP", type: :request do
                  }
                }
              }.to_json,
-             headers: valid_headers
+             headers: engineer_headers
 
         expect(response).to have_http_status(:ok)
         body = JSON.parse(response.body)
@@ -485,12 +511,258 @@ RSpec.describe "MCP", type: :request do
                  arguments: {}
                }
              }.to_json,
-             headers: valid_headers
+             headers: engineer_headers
 
         expect(response).to have_http_status(:bad_request)
         body = JSON.parse(response.body)
         expect(body["error"]["code"]).to eq(-32_602)
         expect(body["error"]["message"]).to include("title is required")
+      end
+    end
+
+    context "with identity-gated mutations" do
+      it "rejects create_task without an identity header" do
+        post_tool_call("create_task", arguments: { title: "X" }, headers: valid_headers)
+
+        expect(response).to have_http_status(:forbidden)
+        body = JSON.parse(response.body)
+        expect(body["error"]["code"]).to eq(-32_003)
+        expect(body["error"]["data"]).to eq("identity required")
+      end
+
+      it "rejects mutations from an unknown email as identity required" do
+        task = create(:task)
+        post_tool_call("update_task",
+                       arguments: { id: task.id, title: "X" },
+                       headers: valid_headers.merge("X-Quicksilver-User-Email" => "ghost@example.test"))
+
+        expect(response).to have_http_status(:forbidden)
+        body = JSON.parse(response.body)
+        expect(body["error"]["code"]).to eq(-32_003)
+        expect(body["error"]["data"]).to eq("identity required")
+      end
+
+      it "rejects mutations from a resolved non-engineer as not authorized" do
+        guest = create(:guest_user)
+        task = create(:task)
+        post_tool_call("complete_task",
+                       arguments: { id: task.id },
+                       headers: valid_headers.merge("X-Quicksilver-User-Email" => guest.email))
+
+        expect(response).to have_http_status(:forbidden)
+        body = JSON.parse(response.body)
+        expect(body["error"]["code"]).to eq(-32_003)
+        expect(body["error"]["data"]).to eq("not authorized")
+      end
+
+      it "allows mutations from a resolved engineer" do
+        post_tool_call("create_task", arguments: { title: "Engineer task" }, headers: engineer_headers)
+
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body["result"]["content"]).to be_an(Array)
+      end
+
+      it "allows mutations from a resolved admin" do
+        admin = create(:admin_user)
+        post_tool_call("create_task",
+                       arguments: { title: "Admin task" },
+                       headers: valid_headers.merge("X-Quicksilver-User-Email" => admin.email))
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "with available_work tool" do
+      it "returns backlog available tasks in size order without requiring identity" do
+        medium = create(:task, board: nil, size: "medium", started_at: nil, completed_at: nil)
+        small = create(:task, board: nil, size: "small", started_at: nil, completed_at: nil)
+        unsized = create(:task, board: nil, size: nil, started_at: nil, completed_at: nil)
+        large = create(:task, board: nil, size: "large", started_at: nil, completed_at: nil)
+        create(:task, board: create(:board), size: "small", started_at: nil, completed_at: nil)
+        create(:task, board: nil, size: "small", started_at: 1.day.ago, completed_at: nil)
+        create(:task, board: nil, size: "small", started_at: nil, completed_at: 1.day.ago)
+
+        post_tool_call("available_work", headers: valid_headers)
+
+        expect(response).to have_http_status(:ok)
+        tasks = JSON.parse(JSON.parse(response.body).dig("result", "content", 0, "text"))["tasks"]
+        expect(tasks.map { |t| t["id"] }).to eq([unsized.id, small.id, medium.id, large.id])
+        expect(tasks.first).to include("title", "description", "priority", "size", "expected_at")
+      end
+    end
+
+    context "with proposed_work tool" do
+      it "returns approved wishlist tasks in priority order without requiring identity" do
+        wishlist = create(:wishlist)
+        high = create(:task, board: wishlist, approved: true, priority: 9)
+        low = create(:task, board: wishlist, approved: true, priority: 1)
+        create(:task, board: wishlist, approved: false, priority: 10)
+        create(:task, board: nil, approved: true, priority: 5)
+
+        post_tool_call("proposed_work", headers: valid_headers)
+
+        expect(response).to have_http_status(:ok)
+        tasks = JSON.parse(JSON.parse(response.body).dig("result", "content", 0, "text"))["tasks"]
+        expect(tasks.map { |t| t["id"] }).to eq([high.id, low.id])
+        expect(tasks.first).to include("title", "description", "priority", "size")
+      end
+    end
+
+    context "with claim_task tool" do
+      it "claims an available task by setting owner and started_at atomically" do
+        task = create(:task, owner: nil, started_at: nil, completed_at: nil)
+
+        post_tool_call("claim_task", arguments: { id: task.id }, headers: engineer_headers)
+
+        expect(response).to have_http_status(:ok)
+        payload = JSON.parse(JSON.parse(response.body).dig("result", "content", 0, "text"))
+        expect(payload["uri"]).to eq("quicksilver://tasks/#{task.id}")
+        expect(payload["task"]["owner_id"]).to eq(engineer.id)
+        expect(payload["task"]["started_at"]).to eq(Date.current.iso8601)
+        expect(task.reload.owner_id).to eq(engineer.id)
+        expect(task.started_at).to eq(Date.current)
+      end
+
+      it "rejects claiming a task that is already started" do
+        task = create(:task, owner: nil, started_at: 1.day.ago, completed_at: nil)
+
+        post_tool_call("claim_task", arguments: { id: task.id }, headers: engineer_headers)
+
+        expect(response).to have_http_status(:bad_request)
+        body = JSON.parse(response.body)
+        expect(body["error"]["code"]).to eq(-32_602)
+        expect(body["error"]["message"]).to match(/already started/i)
+      end
+
+      it "rejects claiming a task owned by another user" do
+        task = create(:task, owner: create(:user), started_at: nil, completed_at: nil)
+
+        post_tool_call("claim_task", arguments: { id: task.id }, headers: engineer_headers)
+
+        expect(response).to have_http_status(:bad_request)
+        body = JSON.parse(response.body)
+        expect(body["error"]["code"]).to eq(-32_602)
+        expect(body["error"]["message"]).to match(/another user/i)
+      end
+
+      it "returns not found when claiming a nonexistent task" do
+        post_tool_call("claim_task", arguments: { id: 999_999 }, headers: engineer_headers)
+
+        expect(response).to have_http_status(:not_found)
+        expect(JSON.parse(response.body).dig("error", "code")).to eq(-32_002)
+      end
+
+      it "rejects claim_task from a resolved non-engineer" do
+        guest = create(:guest_user)
+        task = create(:task, owner: nil, started_at: nil, completed_at: nil)
+
+        post_tool_call("claim_task",
+                       arguments: { id: task.id },
+                       headers: valid_headers.merge("X-Quicksilver-User-Email" => guest.email))
+
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body).dig("error", "code")).to eq(-32_003)
+      end
+    end
+
+    context "with accept_task tool" do
+      it "moves a proposed task onto the backlog and clears approved" do
+        wishlist = create(:wishlist)
+        task = create(:task, board: wishlist, approved: true)
+
+        post_tool_call("accept_task", arguments: { id: task.id }, headers: engineer_headers)
+
+        expect(response).to have_http_status(:ok)
+        payload = JSON.parse(JSON.parse(response.body).dig("result", "content", 0, "text"))
+        expect(payload["uri"]).to eq("quicksilver://tasks/#{task.id}")
+        expect(payload["task"]["board_id"]).to be_nil
+        expect(payload["task"]["approved"]).to be(false)
+        task.reload
+        expect(task.board_id).to be_nil
+        expect(task.approved).to be(false)
+      end
+
+      it "rejects accept_task from a resolved non-engineer" do
+        guest = create(:guest_user)
+        task = create(:task, board: create(:wishlist), approved: true)
+
+        post_tool_call("accept_task",
+                       arguments: { id: task.id },
+                       headers: valid_headers.merge("X-Quicksilver-User-Email" => guest.email))
+
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body).dig("error", "code")).to eq(-32_003)
+      end
+    end
+
+    context "with list_tasks tool" do
+      it "answers 'what am I working on' via owner: me and status: active" do
+        mine = create(:task, owner: engineer, started_at: 1.day.ago, completed_at: nil)
+        create(:task, owner: engineer, started_at: 1.day.ago, completed_at: 1.day.ago)
+        create(:task, owner: create(:user), started_at: 1.day.ago, completed_at: nil)
+
+        post_tool_call("list_tasks", arguments: { owner: "me", status: "active" }, headers: engineer_headers)
+
+        expect(response).to have_http_status(:ok)
+        expect(tool_result["tasks"].map { |t| t["id"] }).to contain_exactly(mine.id)
+      end
+
+      it "filters by board name" do
+        on_wishlist = create(:task, board: create(:wishlist))
+        create(:task, board: nil)
+
+        post_tool_call("list_tasks", arguments: { board: "wishlist" }, headers: valid_headers)
+
+        expect(tool_result["tasks"].map { |t| t["id"] }).to contain_exactly(on_wishlist.id)
+      end
+
+      it "filters to the backlog when board is null" do
+        backlog_task = create(:task, board: nil)
+        create(:task, board: create(:wishlist))
+
+        post_tool_call("list_tasks", arguments: { board: nil }, headers: valid_headers)
+
+        expect(tool_result["tasks"].map { |t| t["id"] }).to contain_exactly(backlog_task.id)
+      end
+
+      it "filters by owner email" do
+        owner = create(:user)
+        theirs = create(:task, owner:)
+        create(:task, owner: create(:user))
+
+        post_tool_call("list_tasks", arguments: { owner: owner.email }, headers: valid_headers)
+
+        expect(tool_result["tasks"].map { |t| t["id"] }).to contain_exactly(theirs.id)
+      end
+
+      it "respects the limit argument" do
+        create_list(:task, 3, board: nil)
+
+        post_tool_call("list_tasks", arguments: { board: nil, limit: 1 }, headers: valid_headers)
+
+        expect(tool_result["tasks"].size).to eq(1)
+      end
+
+      it "rejects owner: me without an identified user" do
+        post_tool_call("list_tasks", arguments: { owner: "me" }, headers: valid_headers)
+
+        expect(response).to have_http_status(:bad_request)
+        expect(JSON.parse(response.body).dig("error", "code")).to eq(-32_602)
+      end
+
+      it "rejects an unknown status" do
+        post_tool_call("list_tasks", arguments: { status: "bogus" }, headers: valid_headers)
+
+        expect(response).to have_http_status(:bad_request)
+        expect(JSON.parse(response.body).dig("error", "code")).to eq(-32_602)
+      end
+
+      it "rejects an unknown board name" do
+        post_tool_call("list_tasks", arguments: { board: "nonexistent" }, headers: valid_headers)
+
+        expect(response).to have_http_status(:bad_request)
+        expect(JSON.parse(response.body).dig("error", "code")).to eq(-32_602)
       end
     end
 


### PR DESCRIPTION
Implements the MCP engineer workflow per `docs/superpowers/specs/2026-06-08-mcp-engineer-workflow-design.md`:
- Tools: `available_work`, `proposed_work`, `claim_task`, `accept_task`, `list_tasks`
- `Mcp::CurrentUser` identity resolution
- `-32003 Forbidden` gating of all mutating tools
- `Task.backlog` scope; updated `docs/MCP.md`

Verification: `bin/rspec` 206 examples / 0 failures (5 pre-existing pending); `bin/rubocop` clean (14 files); `bin/brakeman` 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)